### PR TITLE
Update embed source url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 8.x-1.x
+* Updated embed source url to resolve cors-errors.
 
 # 8.x-1.0-alpha2
 * Added support for www2-subdomain.

--- a/src/Plugin/video_embed_field/Provider/UniTube.php
+++ b/src/Plugin/video_embed_field/Provider/UniTube.php
@@ -26,7 +26,7 @@ class UniTube extends ProviderPluginBase {
       '#suffix' => '</div>',
       '#type' => 'video_embed_iframe',
       '#provider' => 'unitube',
-      '#url' => sprintf('https://webcast.helsinki.fi/unitube/embed.html?id=%s&play=false', $this->getVideoId()),
+      '#url' => sprintf('https://unitube.it.helsinki.fi/unitube/embed.html?id=%s&play=false', $this->getVideoId()),
       '#attributes' => [
         'width' => $width,
         'height' => $height,
@@ -34,7 +34,7 @@ class UniTube extends ProviderPluginBase {
         'marginheight' => '0px',
         'marginwidth' => '0px',
         'frameborder' => '0',
-        'allowfullscreen' => 'allowfullscreen',
+        'allowfullscreen' => 'true',
       ],
     ];
   }


### PR DESCRIPTION
This PR updates the embed source url to match the latest documentation at https://wiki.helsinki.fi/pages/viewpage.action?pageId=350274930 . The old `https://webcast.helsinki.fi/...`-url was causing CORS-errors when trying to load video caption files.